### PR TITLE
feat: Add dialog with tabbed form

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,6 @@
 <div class="p-4">
+  <button mat-raised-button color="primary" (click)="openDialog()">Open Dialog</button>
+  <hr class="my-4">
   <app-tabbed-form></app-tabbed-form>
 </div>
 <router-outlet />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,27 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { TabbedFormComponent } from './tabbed-form/tabbed-form.component';
+import { MatDialog } from '@angular/material/dialog';
+import { DialogWithTabsComponent } from './dialog-with-tabs/dialog-with-tabs.component';
+import { MatButtonModule } from '@angular/material/button'; // Import MatButtonModule
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, TabbedFormComponent],
+  imports: [RouterOutlet, TabbedFormComponent, MatButtonModule], // Add MatButtonModule here
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
 export class AppComponent {
   title = 'angular-jules';
+
+  constructor(public dialog: MatDialog) {}
+
+  openDialog(): void {
+    this.dialog.open(DialogWithTabsComponent, {
+      width: '600px', // You can adjust width and other properties
+      // You can pass data to the dialog here if needed
+      // data: { ... }
+    });
+  }
 }

--- a/src/app/dialog-with-tabs/dialog-with-tabs.component.html
+++ b/src/app/dialog-with-tabs/dialog-with-tabs.component.html
@@ -1,0 +1,1 @@
+<app-tabbed-form></app-tabbed-form>

--- a/src/app/dialog-with-tabs/dialog-with-tabs.component.scss
+++ b/src/app/dialog-with-tabs/dialog-with-tabs.component.scss
@@ -1,0 +1,1 @@
+/* Add any specific styles for the dialog content here */

--- a/src/app/dialog-with-tabs/dialog-with-tabs.component.ts
+++ b/src/app/dialog-with-tabs/dialog-with-tabs.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TabbedFormComponent } from '../tabbed-form/tabbed-form.component'; // Assuming TabbedFormComponent is standalone or imported via another module
+import { MatDialogModule } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-dialog-with-tabs',
+  standalone: true,
+  imports: [
+    CommonModule,
+    TabbedFormComponent,
+    MatDialogModule // Import MatDialogModule here for the dialog content
+  ],
+  templateUrl: './dialog-with-tabs.component.html',
+  styleUrls: ['./dialog-with-tabs.component.scss']
+})
+export class DialogWithTabsComponent {
+
+  constructor() { }
+
+}


### PR DESCRIPTION
Implemented a dialog box that contains the existing tabbed form component.

Changes include:
- Created DialogWithTabsComponent to host the tabbed form.
- Added a button to AppComponent to open the dialog.
- Updated AppComponent to use MatDialog service.
- Ensured necessary Angular Material modules (MatDialogModule, MatButtonModule) are imported in the respective standalone components.
- Verified app.config.ts includes provideAnimations for Angular Material.